### PR TITLE
Fixed up the script

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -1,9 +1,50 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -eEu -o pipefail
 
-cd hubot
+src="/hubot-scripts"
+dst="/hubot"
+
+: "${DEBUG:=}"
+
+if [[ ! -z "$DEBUG" ]]; then
+    set -x
+fi
+
+# Check these two versions
+if [[ ! -d "$src" ]]; then
+    echo "ERROR: src directory ($src) must exist. Cannot continue."
+    exit 1
+fi
+
+if [[ ! -d "$dst" ]]; then
+    echo "ERROR: dst directory ($dst) must exist. Cannot continue."
+    exit 1
+fi
+
+# -L *required* here to dereference symlinks, in the event this
+# is run in kubernetes (as was intended) and the files are presented
+# via a ConfigMap (as was intended!)
+echo "INFO: Copying all files from $src to $dst"
+cp -avL "${src}/"* "${dst}/"
+
+# Some helpful debug output when I encountered errors
+if [[ ! -z "$DEBUG" ]]; then
+    echo "DEBUG: Find output follows:"
+    find "$dst"
+
+    echo "DEBUG: ls $dst output follows:"
+    ls -l "$dst"
+
+    echo "DEBUG: ls pwd output follows:"
+    ls -l
+fi
+
+cd "$dst"
+
+echo "INFO: Running npm install"
 npm install
-export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
+export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
+echo "INFO: Running hubot"
 exec node_modules/.bin/hubot --name "hubot" "$@"

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -4,20 +4,6 @@ metadata:
   labels:
     run: hubot
   name: hubot
-  annotations:
-    pod.beta.kubernetes.io/init-containers: '[
-        {
-            "name": "init",
-            "image": "node",
-            "command": ["npm", "install"],
-            "volumeMounts": [
-                {
-                    "name": "config",
-                    "mountPath": "/hubot"
-                }
-            ]
-        }
-    ]'
 spec:
   replicas: 1
   selector:
@@ -30,22 +16,13 @@ spec:
       labels:
         run: hubot
     spec:
-      volumes:
-        - name: config
-          configMap:
-            name: hubot
       containers:
-      - env:
-        - name: GOOGLE_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GOOGLE_API_KEY
-              name: hubot
-        - name: GOOGLE_CUSTOM_SEARCH
-          valueFrom:
-            secretKeyRef:
-              key: GOOGLE_CUSTOM_SEARCH
-              name: hubot
+      - name: hubot
+        imagePullPolicy: Always
+        image: quay.io/rk295/kubernetes-hubot:latest
+        env:
+        - name: DEBUG
+          value: "true"
         - name: HUBOT_SLACK_TOKEN
           valueFrom:
             secretKeyRef:
@@ -53,9 +30,10 @@ spec:
               name: hubot
         - name: MAX_SEARCH_RESULTS
           value: "1"
-        image: quay.io/nordstrom/hubot
-        imagePullPolicy: Always
-        name: hubot
         volumeMounts:
           - name: config
-            mountPath: /hubot
+            mountPath: /hubot-scripts
+      volumes:
+        - name: config
+          configMap:
+            name: hubot


### PR DESCRIPTION
There is a problem with (I believe >=1.7 of kubernetes) that `configMaps` are presented into a read only directory. Therefore if we present the config into `/hubot` then the `npm install` will fail. 

* Modified the `deployment.yaml` to present the config into another directory.
* Modified the `hubot` script to copy the config from the temporary directory to `/hubot`, making sure to dereference the sym links at the same time. 
* Removed the need for a `InitContainer`; the `hubot` script does that for us. 
* Re-ordered the deployment more in line with the standard we use at `$work`.
* Changed the `Deployment` to use my fork of the container on quay.io.